### PR TITLE
Update to gnome 44

### DIFF
--- a/xyz.diamondb.gtkcord4.yml
+++ b/xyz.diamondb.gtkcord4.yml
@@ -1,6 +1,6 @@
 id: xyz.diamondb.gtkcord4
 runtime: org.gnome.Platform
-runtime-version: '43'
+runtime-version: '44'
 sdk: org.gnome.Sdk
 command: gtkcord4
 


### PR DESCRIPTION
The org.gnome.Platform branch 43 is EOL as of yesterday. This PR bumps it's requested version.

Disclaimer: I don't know anything about flatpak's packaging, so I may of missed something with my 1 character change lol.